### PR TITLE
feat: write directly to disk

### DIFF
--- a/flatcar.json
+++ b/flatcar.json
@@ -1,7 +1,7 @@
 {
   "variables": {
     "location": "nbg1",
-    "server_type": "cx21",
+    "server_type": "cx11",
     "snapshot_prefix": "flatcar-hcloud",
     "image_type": "generic",
     "grub_config": "grub.cfg"
@@ -26,9 +26,7 @@
       "type": "shell",
       "inline": [
         "set -x",
-        "curl -fsSLO https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.bz2",
-        "bunzip2 flatcar_production_qemu_image.img.bz2",
-        "qemu-img convert flatcar_production_qemu_image.img -O raw /dev/sda",
+        "curl -fsSL https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image.bin.bz2 | bzcat | dd if=/dev/stdin of=/dev/sda bs=64k",
         "mount /dev/sda6 /mnt"
       ]
     },


### PR DESCRIPTION
Small refactoring to write directly to disk instead of downloading/converting first - this allows us to use the smaller cx11 instance for building