### PR TITLE
feat: add support for arm64 images

### DIFF
--- a/data.pkr.hcl
+++ b/data.pkr.hcl
@@ -1,8 +1,11 @@
 data "http" "version" {
-  url = "https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt"
+  url = "https://stable.release.flatcar-linux.net/${var.arch}-usr/current/version.txt"
 }
 
 locals {
   // hacky way of reading the "env" formatted file as yaml
   flatcar_version_info = yamldecode(regex_replace(data.http.version.body, "=", ": "))
+
+  // dynamically calculate a server type based on arch
+  server_type = var.server_type == "auto" ? (var.arch == "amd64" ? "cx11" : "cax11") : var.server_type
 }

--- a/flatcar.pkr.hcl
+++ b/flatcar.pkr.hcl
@@ -1,14 +1,14 @@
 locals {
   version       = var.version != "" ? var.version : local.flatcar_version_info.FLATCAR_VERSION_ID
-  download_url  = "https://stable.release.flatcar-linux.net/amd64-usr/${local.version}/flatcar_production_image.bin.bz2"
-  snapshot_name = "${var.snapshot_prefix}${local.version}"
+  download_url  = "https://stable.release.flatcar-linux.net/${var.arch}-usr/${local.version}/flatcar_production_image.bin.bz2"
+  snapshot_name = "${var.snapshot_prefix}${local.version}-${var.arch}"
 }
 
 source "hcloud" "builder" {
   image         = "ubuntu-22.04"
   location      = "${var.location}"
   rescue        = "linux64"
-  server_type   = "${var.server_type}"
+  server_type   = "${local.server_type}"
   snapshot_name = "${local.snapshot_name}"
   ssh_username  = "root"
 

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -13,13 +13,13 @@ variable "image_type" {
 variable "location" {
   type        = string
   description = "hetzner cloud location where to provision the builder vm"
-  default     = "nbg1"
+  default     = "fsn1"
 }
 
 variable "server_type" {
   type        = string
-  description = "hetzner cloud machine type used for building the snapshot"
-  default     = "cx11"
+  description = "hetzner cloud machine type used for building the snapshot (set to 'auto' to use smallest instance matching the desired arch)"
+  default     = "auto"
 }
 
 variable "snapshot_prefix" {
@@ -32,4 +32,14 @@ variable "version" {
   type        = string
   description = "version that should be installed (leave empty to install latest stable version)"
   default     = ""
+}
+
+variable "arch" {
+  type        = string
+  description = "architecture of the image"
+  default     = "amd64"
+  validation {
+    condition     = contains(["amd64", "arm64"], var.arch)
+    error_message = "The `arch` variable must be one of 'amd64', 'arm64'."
+  }
 }


### PR DESCRIPTION
added support for arm64 images.

This will adds a new variable `arch` which can be set to `amd64` to build a arm64 based image.

To make this work, the snapshot name was changed to `$prefix$version-$arch`, the default server type is calculated based on arch and I had to change the default location to `fsn1` as this is currently the only location which allows for arm64 based vms